### PR TITLE
change version to not api/v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aich",
-  "version": "0.8.0+5",
+  "version": "0.8.0+6",
   "description": "Artificial Intelligence Computing Hub",
   "author": "",
   "private": true,

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Version, VERSION_NEUTRAL } from '@nestjs/common';
 import { AppService } from '@/app.service';
 
 @Controller()
@@ -6,7 +6,8 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  @Version(VERSION_NEUTRAL) // Info: (20240828 - Murky) VERSION_NEUTRAL remove "v1" from the url
+  getVersion(): string {
+    return this.appService.getVersion();
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,7 +3,7 @@ import { version } from '@/libs/utils/version';
 
 @Injectable()
 export class AppService {
-  getHello(): string {
+  getVersion(): string {
     return `AICH Version ${version}`;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@/app.module';
-import { VersioningType } from '@nestjs/common';
+import { RequestMethod, VersioningType } from '@nestjs/common';
 import configration from '@/constants/configs/configration';
 async function bootstrap() {
   const port = configration().port;
@@ -12,7 +12,9 @@ async function bootstrap() {
 
   // Info Murky (20240429): Set the global prefix for the API.
   // Url will be accessible at uri/api/...
-  app.setGlobalPrefix('api');
+  app.setGlobalPrefix('api', {
+    exclude: [{ path: '', method: RequestMethod.GET }],
+  });
 
   /* Info Murky (20240429): Enable versioning for the API.
    * How to use:


### PR DESCRIPTION
### DEVELOP

- [X] Description: 目前getVersion不需要經過 /api/v1就可以取得
  
#### Related Issues

- [X] Issue Number:  #85

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.